### PR TITLE
Fix incorrect slashes in URL

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -63,6 +63,6 @@ app.add_middleware(
 
 
 async def run_server() -> None:
-    config = uvicorn.Config(app, host="0.0.0.0", port=8001)
+    config = uvicorn.Config(app, host="0.0.0.0", port=8000)
     server = uvicorn.Server(config)
     await server.serve()

--- a/Webapp/src/components/competition/HeatSummaryTable.tsx
+++ b/Webapp/src/components/competition/HeatSummaryTable.tsx
@@ -50,7 +50,7 @@ export const downloadHeatPDF = async (heats: string[]) => {
 	const response = await axios.get(
 		`${
 			process.env.NEXT_PUBLIC_API_URL_DEV || "/api/"
-		}/heat_pdf?${searchParams.toString()}`,
+		}heat_pdf?${searchParams.toString()}`,
 		{
 			method: "GET",
 			responseType: "blob"

--- a/Webapp/src/components/competition/PhaseScoretable.tsx
+++ b/Webapp/src/components/competition/PhaseScoretable.tsx
@@ -42,8 +42,8 @@ export const PhaseScoreTable = () => {
 	const downloadFile = async () => {
 		const response = await axios.get(
 			`${
-				process.env.NEXT_PUBLIC_API_URL || "/api/"
-			}/phase_pdf/${selectedPhase}`,
+				process.env.NEXT_PUBLIC_API_URL_DEV || "/api/"
+			}phase_pdf/${selectedPhase}`,
 			{
 				method: "GET",
 				responseType: "blob"


### PR DESCRIPTION
Requests to the PDF endpoints were failing due to too many slashes