### PR TITLE
Update PostgreSQL version to 17 in Docker configurations

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
-    image: postgres:16
+    image: postgres:17
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_DB=postgres \
             -p 5432:5432 \
-            postgres:16
+            postgres:17
           for i in $(seq 1 30); do
             docker exec postgres-e2e pg_isready -U postgres && break || sleep 2
           done

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       timeout: 10s
       retries: 3
   db:
-    image: postgres:16
+    image: postgres:17
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]


### PR DESCRIPTION
This pull request upgrades the PostgreSQL version used in our development and CI environments from 16 to 17. This ensures consistency across local development, Docker-based setups, and continuous integration pipelines.

Environment upgrades:

* Updated the PostgreSQL Docker image version to `postgres:17` in `.devcontainer/docker-compose.yml`, `docker-compose.yaml`, and the `azure-pipelines.yml` CI configuration. [[1]](diffhunk://#diff-67a4805fdcc6145d7b3ada2a6099a9b2e91c9d0fd108c22f95d2f01d219793d1L23-R23) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L53-R53) [[3]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L79-R79)